### PR TITLE
increase chart default memory limit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-cli.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-cli.yaml
@@ -19,7 +19,10 @@ body:
         - 1.6.0
         - 1.6.1
         - 1.6.2
+        - 1.6.3
         - 1.7.0
+        - 1.7.1
+        - 1.7.2
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-other.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-other.yaml
@@ -18,7 +18,10 @@ body:
         - 1.6.0
         - 1.6.1
         - 1.6.2
+        - 1.6.3
         - 1.7.0
+        - 1.7.1
+        - 1.7.2
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-webhook.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-webhook.yaml
@@ -18,7 +18,10 @@ body:
         - 1.6.0
         - 1.6.1
         - 1.6.2
+        - 1.6.3
         - 1.7.0
+        - 1.7.1
+        - 1.7.2
     validations:
       required: true
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+## Explanation
+
+<!--
+In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.
+
+THIS IS MANDATORY.
+-->
+
 ## Related issue
 
 <!--

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.7.2-rc1
+
+### Note
+
+- A new flag `maxReportChangeRequests` is added to the Kyverno main container, this flag sets the up-limit of reportchangerequests that a namespace can take, or clusterreportchangerequests if matching kinds are cluster-wide resources. The default limit is set to 1000, and it's recommended to configure it to a small threshold on large clusters. Here the large clusters are considered that a policy report has more than 1k results. 
+
+
 ## v1.7.0-rc1
 
 ### Note

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,17 +6,19 @@
 /pkg/openapi @vyankyGH
 /pkg/policycache @vyankyGH
 /pkg/policy/validate @vyankyGH
-/test @vyankyGH @chipzoller
+/test @vyankyGH @chipzoller @eddycharly
 /docs @chipzoller
 /pkg/cosign @samj1912
 /pkg/engine @samj1912
 /pkg/kyverno @samj1912
 /pkg/policy @samj1912
 /pkg/registryclient @samj1912
-/api/kyverno/v1 @samj1912
+/api/kyverno/v1 @samj1912 @eddycharly
 /pkg/webhooks @prateekpandey14
 /pkg/engine @prateekpandey14
 /pkg/generate @prateekpandey14
 /pkg/policy/generate @prateekpandey14
-/api @prateekpandey14
-/charts @treydock
+/api @prateekpandey14 @eddycharly
+/charts @treydock @eddycharly
+/pkg/autogen @eddycharly
+/pkg/utils @eddycharly

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -160,7 +160,7 @@ imagePullSecrets: {}
 resources:
   # -- Pod resource limits
   limits:
-    memory: 384Mi
+    memory: 512Mi
   # -- Pod resource requests
   requests:
     cpu: 100m

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -44,6 +44,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -365,7 +366,11 @@ func main() {
 			setupLog.Error(err, "tls initialization error")
 			os.Exit(1)
 		}
-		waitForCacheSync(stopCh, kyvernoInformer, kubeInformer, kubeKyvernoInformer)
+		// wait for cache to be synced before use it
+		cache.WaitForCacheSync(stopCh,
+			kubeInformer.Admissionregistration().V1().MutatingWebhookConfigurations().Informer().HasSynced,
+			kubeInformer.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer().HasSynced,
+		)
 
 		// validate the ConfigMap format
 		if err := webhookCfg.ValidateWebhookConfigurations(config.KyvernoNamespace(), config.KyvernoConfigMapName()); err != nil {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -70,6 +70,7 @@ var (
 	clientRateLimitQPS           float64
 	clientRateLimitBurst         int
 	changeRequestLimit           int
+	splitPolicyReport            bool
 	webhookRegistrationTimeout   time.Duration
 	setupLog                     = log.Log.WithName("setup")
 )
@@ -94,7 +95,7 @@ func main() {
 	flag.Func(toggle.AutogenInternalsFlagName, toggle.AutogenInternalsDescription, toggle.AutogenInternalsFlag)
 	flag.DurationVar(&webhookRegistrationTimeout, "webhookRegistrationTimeout", 120*time.Second, "Timeout for webhook registration, e.g., 30s, 1m, 5m.")
 	flag.IntVar(&changeRequestLimit, "maxReportChangeRequests", 1000, "maximum pending report change requests per namespace or for the cluster-wide policy report")
-
+	flag.BoolVar(&splitPolicyReport, "splitPolicyReport", false, "Set the flag to 'true', to enable the split-up PolicyReports per policy.")
 	if err := flag.Set("v", "2"); err != nil {
 		setupLog.Error(err, "failed to set log level")
 		os.Exit(1)
@@ -206,6 +207,7 @@ func main() {
 		kyvernoV1.ClusterPolicies(),
 		kyvernoV1.Policies(),
 		changeRequestLimit,
+		splitPolicyReport,
 		log.Log.WithName("ReportChangeRequestGenerator"),
 	)
 
@@ -218,6 +220,7 @@ func main() {
 		kyvernoV1alpha2.ClusterReportChangeRequests(),
 		kubeInformer.Core().V1().Namespaces(),
 		reportReqGen.CleanupChangeRequest,
+		splitPolicyReport,
 		log.Log.WithName("PolicyReportGenerator"),
 	)
 	if err != nil {

--- a/cmd/kyverno/main.go
+++ b/cmd/kyverno/main.go
@@ -309,7 +309,7 @@ func main() {
 		kyvernoV1.Policies(),
 		kyvernoV1beta1.UpdateRequests(),
 		kubeInformer.Core().V1().Namespaces(),
-		kubeInformer.Core().V1().Pods(),
+		kubeKyvernoInformer.Core().V1().Pods(),
 		eventGenerator,
 		configuration,
 	)

--- a/pkg/background/update_request_controller.go
+++ b/pkg/background/update_request_controller.go
@@ -53,6 +53,8 @@ type controller struct {
 	nsLister   corev1listers.NamespaceLister
 	podLister  corev1listers.PodLister
 
+	informersSynced []cache.InformerSynced
+
 	// queue
 	queue workqueue.RateLimitingInterface
 
@@ -82,7 +84,7 @@ func NewController(
 		urLister:      urLister,
 		nsLister:      namespaceInformer.Lister(),
 		podLister:     podInformer.Lister(),
-		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "generate-request"),
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "update-request"),
 		eventGen:      eventGen,
 		configuration: dynamicConfig,
 	}
@@ -99,6 +101,9 @@ func NewController(
 		UpdateFunc: c.updatePolicy,
 		DeleteFunc: c.deletePolicy,
 	})
+
+	c.informersSynced = []cache.InformerSynced{cpolInformer.Informer().HasSynced, polInformer.Informer().HasSynced, urInformer.Informer().HasSynced, namespaceInformer.Informer().HasSynced, podInformer.Informer().HasSynced}
+
 	return &c
 }
 
@@ -108,6 +113,10 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 
 	logger.Info("starting")
 	defer logger.Info("shutting down")
+
+	if !cache.WaitForNamedCacheSync("background", stopCh, c.informersSynced...) {
+		return
+	}
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)

--- a/pkg/controllers/certmanager/controller.go
+++ b/pkg/controllers/certmanager/controller.go
@@ -23,8 +23,10 @@ type Controller interface {
 }
 
 type controller struct {
-	renewer         *tls.CertRenewer
-	secretLister    corev1listers.SecretLister
+	renewer      *tls.CertRenewer
+	secretLister corev1listers.SecretLister
+	// secretSynced returns true if the secret shared informer has synced at least once
+	secretSynced    cache.InformerSynced
 	secretQueue     chan bool
 	onSecretChanged func() error
 }
@@ -33,6 +35,7 @@ func NewController(secretInformer corev1informers.SecretInformer, certRenewer *t
 	manager := &controller{
 		renewer:         certRenewer,
 		secretLister:    secretInformer.Lister(),
+		secretSynced:    secretInformer.Informer().HasSynced,
 		secretQueue:     make(chan bool, 1),
 		onSecretChanged: onSecretChanged,
 	}

--- a/pkg/controllers/config/controller.go
+++ b/pkg/controllers/config/controller.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -20,6 +21,9 @@ type controller struct {
 	// listers
 	configmapLister corev1listers.ConfigMapLister
 
+	// configmapSynced returns true if the configmap shared informer has synced at least once
+	configmapSynced cache.InformerSynced
+
 	// queue
 	queue workqueue.RateLimitingInterface
 }
@@ -30,12 +34,14 @@ func NewController(configuration config.Configuration, configmapInformer corev1i
 		configmapLister: configmapInformer.Lister(),
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "config-controller"),
 	}
+
+	c.configmapSynced = configmapInformer.Informer().HasSynced
 	controllerutils.AddDefaultEventHandlers(logger, configmapInformer.Informer(), c.queue)
 	return &c
 }
 
 func (c *controller) Run(stopCh <-chan struct{}) {
-	controllerutils.Run(logger, c.queue, workers, maxRetries, c.reconcile, stopCh)
+	controllerutils.Run(controllerName, logger, c.queue, workers, maxRetries, c.reconcile, stopCh, c.configmapSynced)
 }
 
 func (c *controller) reconcile(key, namespace, name string) error {

--- a/pkg/controllers/config/log.go
+++ b/pkg/controllers/config/log.go
@@ -2,4 +2,5 @@ package config
 
 import "sigs.k8s.io/controller-runtime/pkg/log"
 
-var logger = log.Log.WithName("config-controller")
+var controllerName = "config-controller"
+var logger = log.Log.WithName(controllerName)

--- a/pkg/event/controller.go
+++ b/pkg/event/controller.go
@@ -148,30 +148,24 @@ func (gen *Generator) handleErr(err error, key interface{}) {
 }
 
 func (gen *Generator) processNextWorkItem() bool {
-	logger := gen.log
 	obj, shutdown := gen.queue.Get()
 	if shutdown {
 		return false
 	}
 
-	err := func(obj interface{}) error {
-		defer gen.queue.Done(obj)
-		var key Info
-		var ok bool
+	defer gen.queue.Done(obj)
 
-		if key, ok = obj.(Info); !ok {
-			gen.queue.Forget(obj)
-			logger.Info("Incorrect type; expected type 'info'", "obj", obj)
-			return nil
-		}
-		err := gen.syncHandler(key)
-		gen.handleErr(err, obj)
-		return nil
-	}(obj)
-	if err != nil {
-		logger.Error(err, "failed to process next work item")
+	var key Info
+	var ok bool
+	if key, ok = obj.(Info); !ok {
+		gen.queue.Forget(obj)
+		gen.log.Info("Incorrect type; expected type 'info'", "obj", obj)
 		return true
 	}
+
+	err := gen.syncHandler(key)
+	gen.handleErr(err, obj)
+
 	return true
 }
 

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewPolicyFailEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse, blocked bool) *Info {
+func NewPolicyFailEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse, blocked bool) Info {
 	msg := buildPolicyEventMessage(ruleResp, engineResponse.GetResourceSpec(), blocked)
 
-	return &Info{
+	return Info{
 		Kind:      getPolicyKind(engineResponse.Policy),
 		Name:      engineResponse.PolicyResponse.Policy.Name,
 		Namespace: engineResponse.PolicyResponse.Policy.Namespace,
@@ -50,39 +50,42 @@ func getPolicyKind(policy kyvernov1.PolicyInterface) string {
 	return "ClusterPolicy"
 }
 
-func NewPolicyAppliedEvent(source Source, engineResponse *response.EngineResponse) *Info {
+func NewPolicyAppliedEvent(source Source, engineResponse *response.EngineResponse) Info {
 	resource := engineResponse.PolicyResponse.Resource
+	var bldr strings.Builder
+	defer bldr.Reset()
 
-	var msg string
 	if resource.Namespace != "" {
-		msg = fmt.Sprintf("%s %s/%s: pass", resource.Kind, resource.Namespace, resource.Name)
+		fmt.Fprintf(&bldr, "%s %s/%s: pass", resource.Kind, resource.Namespace, resource.Name)
 	} else {
-		msg = fmt.Sprintf("%s %s: pass", resource.Kind, resource.Name)
+		fmt.Fprintf(&bldr, "%s %s: pass", resource.Kind, resource.Name)
 	}
 
-	return &Info{
+	return Info{
 		Kind:      getPolicyKind(engineResponse.Policy),
 		Name:      engineResponse.PolicyResponse.Policy.Name,
 		Namespace: engineResponse.PolicyResponse.Policy.Namespace,
 		Reason:    PolicyApplied.String(),
 		Source:    source,
-		Message:   msg,
+		Message:   bldr.String(),
 	}
 }
 
-func NewResourceViolationEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse) *Info {
-	policyName := engineResponse.Policy.GetName()
-	status := ruleResp.Status.String()
-	msg := fmt.Sprintf("policy %s/%s %s: %s", policyName, ruleResp.Name, status, ruleResp.Message)
+func NewResourceViolationEvent(source Source, reason Reason, engineResponse *response.EngineResponse, ruleResp *response.RuleResponse) Info {
+	var bldr strings.Builder
+	defer bldr.Reset()
+
+	fmt.Fprintf(&bldr, "policy %s/%s %s: %s", engineResponse.Policy.GetName(),
+		ruleResp.Name, ruleResp.Status.String(), ruleResp.Message)
 	resource := engineResponse.GetResourceSpec()
 
-	return &Info{
+	return Info{
 		Kind:      resource.Kind,
 		Name:      resource.Name,
 		Namespace: resource.Namespace,
 		Reason:    reason.String(),
 		Source:    source,
-		Message:   msg,
+		Message:   bldr.String(),
 	}
 }
 

--- a/pkg/event/util.go
+++ b/pkg/event/util.go
@@ -2,7 +2,7 @@ package event
 
 const eventWorkQueueName = "kyverno-events"
 
-const workQueueRetryLimit = 10
+const workQueueRetryLimit = 3
 
 // Info defines the event details
 type Info struct {

--- a/pkg/policy/policy_controller.go
+++ b/pkg/policy/policy_controller.go
@@ -407,7 +407,7 @@ func (pc *PolicyController) enqueuePolicy(policy kyvernov1.PolicyInterface) {
 }
 
 // Run begins watching and syncing.
-func (pc *PolicyController) Run(workers int, reconcileCh <-chan bool, stopCh <-chan struct{}) {
+func (pc *PolicyController) Run(workers int, reconcileCh <-chan bool, cleanupChangeRequest <-chan policyreport.ReconcileInfo, stopCh <-chan struct{}) {
 	logger := pc.log
 
 	defer utilruntime.HandleCrash()
@@ -436,7 +436,7 @@ func (pc *PolicyController) Run(workers int, reconcileCh <-chan bool, stopCh <-c
 		go wait.Until(pc.worker, time.Second, stopCh)
 	}
 
-	go pc.forceReconciliation(reconcileCh, stopCh)
+	go pc.forceReconciliation(reconcileCh, cleanupChangeRequest, stopCh)
 
 	<-stopCh
 }

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -170,7 +170,7 @@ func generateSuccessEvents(log logr.Logger, ers []*response.EngineResponse) (eve
 		if !er.IsFailed() {
 			logger.V(4).Info("generating event on policy for success rules")
 			e := event.NewPolicyAppliedEvent(event.PolicyController, er)
-			eventInfos = append(eventInfos, *e)
+			eventInfos = append(eventInfos, e)
 		}
 	}
 
@@ -196,10 +196,10 @@ func generateFailEventsPerEr(log logr.Logger, er *response.EngineResponse) []eve
 		}
 
 		eventResource := event.NewResourceViolationEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
-		eventInfos = append(eventInfos, *eventResource)
+		eventInfos = append(eventInfos, eventResource)
 
 		eventPolicy := event.NewPolicyFailEvent(event.PolicyController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], false)
-		eventInfos = append(eventInfos, *eventPolicy)
+		eventInfos = append(eventInfos, eventPolicy)
 	}
 
 	if len(eventInfos) > 0 {

--- a/pkg/policy/report.go
+++ b/pkg/policy/report.go
@@ -40,36 +40,71 @@ func (pc *PolicyController) report(engineResponses []*response.EngineResponse, l
 }
 
 // forceReconciliation forces a background scan by adding all policies to the workqueue
-func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, stopCh <-chan struct{}) {
+func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, cleanupChangeRequest <-chan policyreport.ReconcileInfo, stopCh <-chan struct{}) {
 	logger := pc.log.WithName("forceReconciliation")
 	ticker := time.NewTicker(pc.reconcilePeriod)
 
+	changeRequestMapperNamespace := make(map[string]bool)
 	for {
 		select {
 		case <-ticker.C:
 			logger.Info("performing the background scan", "scan interval", pc.reconcilePeriod.String())
-			if err := pc.policyReportEraser.CleanupReportChangeRequests(cleanupReportChangeRequests); err != nil {
+			if err := pc.policyReportEraser.CleanupReportChangeRequests(cleanupReportChangeRequests, nil); err != nil {
 				logger.Error(err, "failed to cleanup report change requests")
 			}
 
-			if err := pc.policyReportEraser.EraseResultsEntries(eraseResultsEntries); err != nil {
+			if err := pc.policyReportEraser.EraseResultEntries(eraseResultEntries, nil); err != nil {
 				logger.Error(err, "continue reconciling policy reports")
 			}
 
 			pc.requeuePolicies()
+			pc.prGenerator.MapperInvalidate()
 
 		case erase := <-reconcileCh:
 			logger.Info("received the reconcile signal, reconciling policy report")
-			if err := pc.policyReportEraser.CleanupReportChangeRequests(cleanupReportChangeRequests); err != nil {
+			if err := pc.policyReportEraser.CleanupReportChangeRequests(cleanupReportChangeRequests, nil); err != nil {
 				logger.Error(err, "failed to cleanup report change requests")
 			}
 
 			if erase {
-				if err := pc.policyReportEraser.EraseResultsEntries(eraseResultsEntries); err != nil {
+				if err := pc.policyReportEraser.EraseResultEntries(eraseResultEntries, nil); err != nil {
 					logger.Error(err, "continue reconciling policy reports")
 				}
 			}
 
+			pc.requeuePolicies()
+
+		case info := <-cleanupChangeRequest:
+			if info.Namespace == nil {
+				continue
+			}
+
+			ns := *info.Namespace
+			if exist := changeRequestMapperNamespace[ns]; exist {
+				continue
+			}
+
+			changeRequestMapperNamespace[ns] = true
+			if err := pc.policyReportEraser.CleanupReportChangeRequests(cleanupReportChangeRequests,
+				map[string]string{policyreport.ResourceLabelNamespace: ns}); err != nil {
+				logger.Error(err, "failed to cleanup report change requests for the given namespace", "namespace", ns)
+			} else {
+				logger.V(3).Info("cleaned up report change requests for the given namespace", "namespace", ns)
+			}
+
+			changeRequestMapperNamespace[ns] = false
+
+			if err := pc.policyReportEraser.EraseResultEntries(eraseResultEntries, info.Namespace); err != nil {
+				logger.Error(err, "failed to erase result entries for the report", "report", policyreport.GeneratePolicyReportName(ns))
+			} else {
+				logger.V(3).Info("wiped out result entries for the report", "report", policyreport.GeneratePolicyReportName(ns))
+			}
+
+			if info.MapperInactive {
+				pc.prGenerator.MapperInactive(ns)
+			} else {
+				pc.prGenerator.MapperReset(ns)
+			}
 			pc.requeuePolicies()
 
 		case <-stopCh:
@@ -78,18 +113,22 @@ func (pc *PolicyController) forceReconciliation(reconcileCh <-chan bool, stopCh 
 	}
 }
 
-func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister) error {
+func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, labels map[string]string) error {
 	var errors []string
 
 	var gracePeriod int64 = 0
 	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
 
-	err := pclient.KyvernoV1alpha2().ClusterReportChangeRequests().DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{})
+	selector := &metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+
+	err := pclient.KyvernoV1alpha2().ClusterReportChangeRequests().DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)})
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
 
-	err = pclient.KyvernoV1alpha2().ReportChangeRequests(config.KyvernoNamespace()).DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{})
+	err = pclient.KyvernoV1alpha2().ReportChangeRequests(config.KyvernoNamespace()).DeleteCollection(context.TODO(), deleteOptions, metav1.ListOptions{LabelSelector: metav1.FormatLabelSelector(selector)})
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -101,13 +140,47 @@ func cleanupReportChangeRequests(pclient kyvernoclient.Interface, rcrLister kyve
 	return fmt.Errorf("%v", strings.Join(errors, ";"))
 }
 
-func eraseResultsEntries(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister) error {
+func eraseResultEntries(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error {
 	selector, err := metav1.LabelSelectorAsSelector(policyreport.LabelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to erase results entries %v", err)
 	}
 
 	var errors []string
+	var polrName string
+
+	if ns != nil {
+		polrName = policyreport.GeneratePolicyReportName(*ns)
+		if polrName != "" {
+			polr, err := reportLister.PolicyReports(*ns).Get(polrName)
+			if err != nil {
+				return fmt.Errorf("failed to erase results entries for PolicyReport %s: %v", polrName, err)
+			}
+
+			polr.Results = []v1alpha2.PolicyReportResult{}
+			polr.Summary = v1alpha2.PolicyReportSummary{}
+			if _, err = pclient.Wgpolicyk8sV1alpha2().PolicyReports(polr.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+				errors = append(errors, fmt.Sprintf("%s/%s/%s: %v", polr.Kind, polr.Namespace, polr.Name, err))
+			}
+		} else {
+			cpolr, err := clusterReportLister.Get(polrName)
+			if err != nil {
+				errors = append(errors, err.Error())
+			}
+
+			cpolr.Results = []v1alpha2.PolicyReportResult{}
+			cpolr.Summary = v1alpha2.PolicyReportSummary{}
+			if _, err = pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("failed to erase results entries for ClusterPolicyReport %s: %v", polrName, err)
+			}
+		}
+
+		if len(errors) == 0 {
+			return nil
+		}
+
+		return fmt.Errorf("failed to erase results entries for report %s: %v", polrName, strings.Join(errors, ";"))
+	}
 
 	if polrs, err := reportLister.List(selector); err != nil {
 		errors = append(errors, err.Error())

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -28,6 +28,7 @@ const (
 
 	// the following labels are used to list rcr / crcr
 	ResourceLabelNamespace string = "kyverno.io/resource.namespace"
+	policyLabel            string = "kyverno.io/policy-name"
 	deletedLabelPolicy     string = "kyverno.io/delete.policy"
 	deletedLabelRule       string = "kyverno.io/delete.rule"
 
@@ -54,6 +55,13 @@ func GeneratePolicyReportName(ns string) string {
 	}
 
 	return name
+}
+
+func TrimmedName(s string) string {
+	if len(s) > 63 {
+		return s[:63]
+	}
+	return s
 }
 
 // GeneratePRsFromEngineResponse generate Violations from engine responses
@@ -209,6 +217,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 
 	obj.SetLabels(map[string]string{
 		ResourceLabelNamespace: info.Namespace,
+		policyLabel:            TrimmedName(info.PolicyName),
 		appVersion:             version.BuildVersion,
 	})
 }

--- a/pkg/policyreport/builder.go
+++ b/pkg/policyreport/builder.go
@@ -27,7 +27,7 @@ const (
 	appVersion string = "app.kubernetes.io/version"
 
 	// the following labels are used to list rcr / crcr
-	resourceLabelNamespace string = "kyverno.io/resource.namespace"
+	ResourceLabelNamespace string = "kyverno.io/resource.namespace"
 	deletedLabelPolicy     string = "kyverno.io/delete.policy"
 	deletedLabelRule       string = "kyverno.io/delete.rule"
 
@@ -35,6 +35,9 @@ const (
 	// there would be a problem if use labels as the value could exceed 63 chars
 	deletedAnnotationResourceName string = "kyverno.io/delete.resource.name"
 	deletedAnnotationResourceKind string = "kyverno.io/delete.resource.kind"
+
+	inactiveLabelKey string = "kyverno.io/report.status"
+	inactiveLabelVal string = "inactive"
 
 	// SourceValue is the static value for PolicyReportResult.Source
 	SourceValue = "Kyverno"
@@ -205,7 +208,7 @@ func set(obj *unstructured.Unstructured, info Info) {
 	}
 
 	obj.SetLabels(map[string]string{
-		resourceLabelNamespace: info.Namespace,
+		ResourceLabelNamespace: info.Namespace,
 		appVersion:             version.BuildVersion,
 	})
 }
@@ -219,7 +222,7 @@ func setRequestDeletionLabels(req *unstructured.Unstructured, info Info) bool {
 		})
 
 		labels := req.GetLabels()
-		labels[resourceLabelNamespace] = info.Results[0].Resource.Namespace
+		labels[ResourceLabelNamespace] = info.Results[0].Resource.Namespace
 		req.SetLabels(labels)
 		return true
 

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -36,19 +36,23 @@ type changeRequestCreator struct {
 	mutex sync.RWMutex
 	queue []string
 
+	// splitPolicyReport enable/disable the PolicyReport split-up per policy feature
+	splitPolicyReport bool
+
 	tickerInterval time.Duration
 
 	log logr.Logger
 }
 
-func newChangeRequestCreator(client kyvernoclient.Interface, tickerInterval time.Duration, log logr.Logger) creator {
+func newChangeRequestCreator(client kyvernoclient.Interface, tickerInterval time.Duration, splitPolicyReport bool, log logr.Logger) creator {
 	return &changeRequestCreator{
-		client:         client,
-		RCRCache:       cache.New(0, 24*time.Hour),
-		CRCRCache:      cache.New(0, 24*time.Hour),
-		queue:          []string{},
-		tickerInterval: tickerInterval,
-		log:            log,
+		client:            client,
+		RCRCache:          cache.New(0, 24*time.Hour),
+		CRCRCache:         cache.New(0, 24*time.Hour),
+		queue:             []string{},
+		tickerInterval:    tickerInterval,
+		splitPolicyReport: splitPolicyReport,
+		log:               log,
 	}
 }
 
@@ -110,10 +114,23 @@ func (c *changeRequestCreator) run(stopChan <-chan struct{}) {
 	ticker := time.NewTicker(c.tickerInterval)
 	defer ticker.Stop()
 
+	if c.splitPolicyReport {
+		err := CleanupPolicyReport(c.client)
+		if err != nil {
+			c.log.Error(err, "failed to delete old reports")
+		}
+	}
+
 	for {
 		select {
 		case <-ticker.C:
-			requests, size := c.mergeRequests()
+			requests := []*unstructured.Unstructured{}
+			var size int
+			if c.splitPolicyReport {
+				requests, size = c.mergeRequestsPerPolicy()
+			} else {
+				requests, size = c.mergeRequests()
+			}
 			for _, request := range requests {
 				if err := c.create(request); err != nil {
 					c.log.Error(err, "failed to create report change request", "req", request.Object)
@@ -216,7 +233,96 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 			results = append(results, mergedNamespacedRCR)
 		}
 	}
+	return
+}
 
+// mergeRequests merges all current cached requests per policy
+// it blocks writing to the cache
+func (c *changeRequestCreator) mergeRequestsPerPolicy() (results []*unstructured.Unstructured, size int) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	mergedCRCR := make(map[string]*unstructured.Unstructured)
+	mergedRCR := make(map[string]*unstructured.Unstructured)
+	size = len(c.queue)
+
+	for _, uid := range c.queue {
+		if unstr, ok := c.CRCRCache.Get(uid); ok {
+			if crcr, ok := unstr.(*unstructured.Unstructured); ok {
+				policyName := crcr.GetLabels()[policyLabel]
+				mergedPolicyCRCR, ok := mergedCRCR[policyName]
+				if !ok {
+					mergedPolicyCRCR = &unstructured.Unstructured{}
+				}
+
+				if isDeleteRequest(crcr) {
+					if !reflect.DeepEqual(mergedPolicyCRCR, &unstructured.Unstructured{}) {
+						results = append(results, mergedPolicyCRCR)
+						mergedCRCR[policyName] = &unstructured.Unstructured{}
+					}
+
+					results = append(results, crcr)
+				} else {
+					if reflect.DeepEqual(mergedPolicyCRCR, &unstructured.Unstructured{}) {
+						mergedCRCR[policyName] = crcr
+						continue
+					}
+
+					if ok := merge(mergedPolicyCRCR, crcr); !ok {
+						results = append(results, mergedPolicyCRCR)
+						mergedCRCR[policyName] = crcr
+					} else {
+						mergedCRCR[policyName] = mergedPolicyCRCR
+					}
+				}
+			}
+			continue
+		}
+
+		if unstr, ok := c.RCRCache.Get(uid); ok {
+			if rcr, ok := unstr.(*unstructured.Unstructured); ok {
+				policyName := rcr.GetLabels()[policyLabel]
+				resourceNS := rcr.GetLabels()[ResourceLabelNamespace]
+				mergedNamespacedRCR, ok := mergedRCR[policyName+resourceNS]
+				if !ok {
+					mergedNamespacedRCR = &unstructured.Unstructured{}
+				}
+
+				if isDeleteRequest(rcr) {
+					if !reflect.DeepEqual(mergedNamespacedRCR, &unstructured.Unstructured{}) {
+						results = append(results, mergedNamespacedRCR)
+						mergedRCR[policyName+resourceNS] = &unstructured.Unstructured{}
+					}
+
+					results = append(results, rcr)
+				} else {
+					if reflect.DeepEqual(mergedNamespacedRCR, &unstructured.Unstructured{}) {
+						mergedRCR[policyName+resourceNS] = rcr
+						continue
+					}
+
+					if ok := merge(mergedNamespacedRCR, rcr); !ok {
+						results = append(results, mergedNamespacedRCR)
+						mergedRCR[policyName+resourceNS] = rcr
+					} else {
+						mergedRCR[policyName+resourceNS] = mergedNamespacedRCR
+					}
+				}
+			}
+		}
+	}
+
+	for _, mergedPolicyCRCR := range mergedCRCR {
+		if !reflect.DeepEqual(mergedPolicyCRCR, &unstructured.Unstructured{}) {
+			results = append(results, mergedPolicyCRCR)
+		}
+	}
+
+	for _, mergedNamespacedRCR := range mergedRCR {
+		if !reflect.DeepEqual(mergedNamespacedRCR, &unstructured.Unstructured{}) {
+			results = append(results, mergedNamespacedRCR)
+		}
+	}
 	return
 }
 

--- a/pkg/policyreport/changerequestcreator.go
+++ b/pkg/policyreport/changerequestcreator.go
@@ -177,7 +177,7 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 
 		if unstr, ok := c.RCRCache.Get(uid); ok {
 			if rcr, ok := unstr.(*unstructured.Unstructured); ok {
-				resourceNS := rcr.GetLabels()[resourceLabelNamespace]
+				resourceNS := rcr.GetLabels()[ResourceLabelNamespace]
 				mergedNamespacedRCR, ok := mergedRCR[resourceNS]
 				if !ok {
 					mergedNamespacedRCR = &unstructured.Unstructured{}
@@ -223,8 +223,8 @@ func (c *changeRequestCreator) mergeRequests() (results []*unstructured.Unstruct
 // merge merges elements from a source object into a
 // destination object if they share the same namespace label
 func merge(dst, src *unstructured.Unstructured) bool {
-	dstNS := dst.GetLabels()[resourceLabelNamespace]
-	srcNS := src.GetLabels()[resourceLabelNamespace]
+	dstNS := dst.GetLabels()[ResourceLabelNamespace]
+	srcNS := src.GetLabels()[ResourceLabelNamespace]
 	if dstNS != srcNS {
 		return false
 	}

--- a/pkg/policyreport/mapper.go
+++ b/pkg/policyreport/mapper.go
@@ -1,0 +1,24 @@
+package policyreport
+
+import cmap "github.com/orcaman/concurrent-map"
+
+type concurrentMap struct{ cmap.ConcurrentMap }
+
+func (m concurrentMap) increase(ns string) {
+	count, ok := m.Get(ns)
+	if ok && count != -1 {
+		m.Set(ns, count.(int)+1)
+	} else {
+		m.Set(ns, 1)
+	}
+}
+
+func (m concurrentMap) decrease(keyHash string) {
+	_, ns := parseKeyHash(keyHash)
+	count, ok := m.Get(ns)
+	if ok && count.(int) > 0 {
+		m.Set(ns, count.(int)-1)
+	} else {
+		m.Set(ns, 0)
+	}
+}

--- a/pkg/policyreport/policyreport.go
+++ b/pkg/policyreport/policyreport.go
@@ -16,21 +16,21 @@ import (
 )
 
 type PolicyReportEraser interface {
-	CleanupReportChangeRequests(cleanup CleanupReportChangeRequests) error
-	EraseResultsEntries(erase EraseResultsEntries) error
+	CleanupReportChangeRequests(cleanup CleanupReportChangeRequests, labels map[string]string) error
+	EraseResultEntries(erase EraseResultEntries, ns *string) error
 }
 
 type (
-	CleanupReportChangeRequests = func(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister) error
-	EraseResultsEntries         = func(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister) error
+	CleanupReportChangeRequests = func(pclient kyvernoclient.Interface, rcrLister kyvernov1alpha2listers.ReportChangeRequestLister, crcrLister kyvernov1alpha2listers.ClusterReportChangeRequestLister, labels map[string]string) error
+	EraseResultEntries          = func(pclient kyvernoclient.Interface, reportLister policyreportv1alpha2listers.PolicyReportLister, clusterReportLister policyreportv1alpha2listers.ClusterPolicyReportLister, ns *string) error
 )
 
-func (g *ReportGenerator) CleanupReportChangeRequests(cleanup CleanupReportChangeRequests) error {
-	return cleanup(g.pclient, g.reportChangeRequestLister, g.clusterReportChangeRequestLister)
+func (g *ReportGenerator) CleanupReportChangeRequests(cleanup CleanupReportChangeRequests, labels map[string]string) error {
+	return cleanup(g.pclient, g.reportChangeRequestLister, g.clusterReportChangeRequestLister, labels)
 }
 
-func (g *ReportGenerator) EraseResultsEntries(erase EraseResultsEntries) error {
-	return erase(g.pclient, g.reportLister, g.clusterReportLister)
+func (g *ReportGenerator) EraseResultEntries(erase EraseResultEntries, ns *string) error {
+	return erase(g.pclient, g.reportLister, g.clusterReportLister, ns)
 }
 
 type deletedResource struct {
@@ -52,7 +52,7 @@ func buildLabelForDeletedResource(labels, annotations map[string]string) *delete
 	return &deletedResource{
 		kind: kind,
 		name: name,
-		ns:   labels[resourceLabelNamespace],
+		ns:   labels[ResourceLabelNamespace],
 	}
 }
 

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -67,6 +67,8 @@ type ReportGenerator struct {
 	reportChangeRequestLister        kyvernov1alpha2listers.ReportChangeRequestLister
 	clusterReportChangeRequestLister kyvernov1alpha2listers.ClusterReportChangeRequestLister
 	nsLister                         corev1listers.NamespaceLister
+	// splitPolicyReport enable/disable the PolicyReport split-up per policy feature
+	splitPolicyReport bool
 
 	informersSynced []cache.InformerSynced
 
@@ -91,6 +93,7 @@ func NewReportGenerator(
 	clusterReportReqInformer kyvernov1alpha2informers.ClusterReportChangeRequestInformer,
 	namespace corev1informers.NamespaceInformer,
 	cleanupChangeRequest chan<- ReconcileInfo,
+	splitPolicyReport bool,
 	log logr.Logger,
 ) (*ReportGenerator, error) {
 	gen := &ReportGenerator{
@@ -101,6 +104,7 @@ func NewReportGenerator(
 		reportReqInformer:        reportReqInformer,
 		clusterReportReqInformer: clusterReportReqInformer,
 		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), prWorkQueueName),
+		splitPolicyReport:        splitPolicyReport,
 		ReconcileCh:              make(chan bool, 10),
 		cleanupChangeRequest:     cleanupChangeRequest,
 		log:                      log,
@@ -120,7 +124,7 @@ func NewReportGenerator(
 // - <namespace name> for the resource
 // - "" for cluster wide resource
 // - "deletedpolicy/policyName/ruleName(optional)" for a deleted policy or rule
-func generateCacheKey(changeRequest interface{}) string {
+func (g *ReportGenerator) generateCacheKey(changeRequest interface{}) string {
 	if request, ok := changeRequest.(*kyvernov1alpha2.ReportChangeRequest); ok {
 		label := request.GetLabels()
 		policy := label[deletedLabelPolicy]
@@ -133,7 +137,12 @@ func generateCacheKey(changeRequest interface{}) string {
 		if ns == "" {
 			ns = "default"
 		}
-		return ns
+		if g.splitPolicyReport {
+			policy = label[policyLabel]
+			return strings.Join([]string{ns, policy}, "/")
+		} else {
+			return ns
+		}
 	} else if request, ok := changeRequest.(*kyvernov1alpha2.ClusterReportChangeRequest); ok {
 		label := request.GetLabels()
 		policy := label[deletedLabelPolicy]
@@ -141,9 +150,13 @@ func generateCacheKey(changeRequest interface{}) string {
 		if rule != "" || policy != "" {
 			return strings.Join([]string{deletedPolicyKey, policy, rule}, "/")
 		}
-		return ""
+		if g.splitPolicyReport {
+			policy = label[policyLabel]
+			return strings.Join([]string{"", policy}, "/")
+		} else {
+			return ""
+		}
 	}
-
 	return ""
 }
 
@@ -171,7 +184,7 @@ func (g *ReportGenerator) addReportChangeRequest(obj interface{}) {
 		return
 	}
 
-	key := generateCacheKey(obj)
+	key := g.generateCacheKey(obj)
 	g.queue.Add(key)
 }
 
@@ -187,7 +200,7 @@ func (g *ReportGenerator) updateReportChangeRequest(old interface{}, cur interfa
 		return
 	}
 
-	key := generateCacheKey(cur)
+	key := g.generateCacheKey(cur)
 	g.queue.Add(key)
 }
 
@@ -197,7 +210,7 @@ func (g *ReportGenerator) addClusterReportChangeRequest(obj interface{}) {
 		return
 	}
 
-	key := generateCacheKey(obj)
+	key := g.generateCacheKey(obj)
 	g.queue.Add(key)
 }
 
@@ -213,7 +226,8 @@ func (g *ReportGenerator) updateClusterReportChangeRequest(old interface{}, cur 
 		return
 	}
 
-	g.queue.Add("")
+	key := g.generateCacheKey(cur)
+	g.queue.Add(key)
 }
 
 func (g *ReportGenerator) deletePolicyReport(obj interface{}) {
@@ -321,22 +335,43 @@ func (g *ReportGenerator) handleErr(err error, key interface{}, aggregatedReques
 }
 
 // syncHandler reconciles clusterPolicyReport if namespace == ""
-// otherwise it updates policyReport
+// otherwise it updates policyReport. the key is of type "namespace/policyname"
 func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{}, err error) {
 	g.log.V(4).Info("syncing policy report", "key", key)
-	namespace := key
 
 	if policy, rule, ok := isDeletedPolicyKey(key); ok {
 		g.log.V(4).Info("sync policy report on policy deletion")
 		return g.removePolicyEntryFromReport(policy, rule)
 	}
-
-	new, aggregatedRequests, err := g.aggregateReports(namespace)
+	var namespace, policyName string
+	if g.splitPolicyReport {
+		namespace = strings.Split(key, "/")[0]
+		policyName = strings.Split(key, "/")[1]
+	} else {
+		namespace = key
+	}
+	new, aggregatedRequests, err := g.aggregateReports(namespace, policyName)
 	if err != nil {
 		return aggregatedRequests, fmt.Errorf("failed to aggregate reportChangeRequest results %v", err)
 	}
 
-	report, err := g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
+	if g.splitPolicyReport {
+		deleteResources := getDeletedResources(aggregatedRequests)
+		if len(deleteResources) != 0 {
+			for _, dr := range deleteResources {
+				if err := g.updateReportsForDeletedResource(dr.name, new, aggregatedRequests); err != nil {
+					return aggregatedRequests, err
+				}
+			}
+		}
+	}
+
+	var report *policyreportv1alpha2.PolicyReport
+	if g.splitPolicyReport {
+		report, err = g.reportLister.PolicyReports(namespace).Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
+	} else {
+		report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
+	}
 	if err == nil {
 		if val, ok := report.GetLabels()[inactiveLabelKey]; ok && val == inactiveLabelVal {
 			g.log.Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
@@ -344,8 +379,9 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 		}
 	}
 
+	// Delete changes request does not have the policyName label set
 	var old interface{}
-	if old, err = g.createReportIfNotPresent(namespace, new, aggregatedRequests); err != nil {
+	if old, err = g.createReportIfNotPresent(namespace, policyName, new, aggregatedRequests); err != nil {
 		return aggregatedRequests, err
 	}
 
@@ -365,7 +401,7 @@ func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{
 
 // createReportIfNotPresent creates cluster / policyReport if not present
 // return the existing report if exist
-func (g *ReportGenerator) createReportIfNotPresent(namespace string, new *unstructured.Unstructured, aggregatedRequests interface{}) (report interface{}, err error) {
+func (g *ReportGenerator) createReportIfNotPresent(namespace, policyName string, new *unstructured.Unstructured, aggregatedRequests interface{}) (report interface{}, err error) {
 	log := g.log.WithName("createReportIfNotPresent")
 	obj, hasDuplicate, err := updateResults(new.UnstructuredContent(), new.UnstructuredContent(), nil)
 	if hasDuplicate && err != nil {
@@ -387,7 +423,11 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace string, new *unstru
 			return nil, nil
 		}
 
-		report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
+		if g.splitPolicyReport {
+			report, err = g.reportLister.PolicyReports(namespace).Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
+		} else {
+			report, err = g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
+		}
 		if err != nil {
 			if apierrors.IsNotFound(err) && new != nil {
 				polr, err := convertToPolr(new)
@@ -407,7 +447,12 @@ func (g *ReportGenerator) createReportIfNotPresent(namespace string, new *unstru
 			return nil, fmt.Errorf("unable to get policyReport: %v", err)
 		}
 	} else {
-		report, err = g.clusterReportLister.Get(GeneratePolicyReportName(namespace))
+
+		if g.splitPolicyReport {
+			report, err = g.clusterReportLister.Get(TrimmedName(GeneratePolicyReportName(namespace) + "-" + policyName))
+		} else {
+			report, err = g.clusterReportLister.Get(GeneratePolicyReportName(namespace))
+		}
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				if new != nil {
@@ -485,6 +530,7 @@ func (g *ReportGenerator) removeFromClusterPolicyReport(policyName, ruleName str
 }
 
 func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) error {
+
 	namespaces, err := g.client.ListResource("", "Namespace", "", nil)
 	if err != nil {
 		return fmt.Errorf("unable to list namespace %v", err)
@@ -520,6 +566,7 @@ func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) er
 		gv := policyreportv1alpha2.SchemeGroupVersion
 		gvk := schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: "PolicyReport"}
 		r.SetGroupVersionKind(gvk)
+
 		if _, err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(r.GetNamespace()).Update(context.TODO(), r, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update PolicyReport %s %v", r.GetName(), err)
 		}
@@ -528,7 +575,7 @@ func (g *ReportGenerator) removeFromPolicyReport(policyName, ruleName string) er
 }
 
 // aggregateReports aggregates cluster / report change requests to a policy report
-func (g *ReportGenerator) aggregateReports(namespace string) (
+func (g *ReportGenerator) aggregateReports(namespace, policyName string) (
 	report *unstructured.Unstructured,
 	aggregatedRequests interface{},
 	err error,
@@ -538,14 +585,19 @@ func (g *ReportGenerator) aggregateReports(namespace string) (
 		g.log.Error(err, "failed to get Kyverno namespace, policy reports will not be garbage collected upon termination")
 	}
 
+	selector := labels.NewSelector()
 	if namespace == "" {
-		selector := labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion}))
+		if g.splitPolicyReport {
+			selector = labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, policyLabel: TrimmedName(policyName)}))
+		} else {
+			selector = labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion}))
+		}
 		requests, err := g.clusterReportChangeRequestLister.List(selector)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to list ClusterReportChangeRequests within: %v", err)
 		}
 
-		if report, aggregatedRequests, err = mergeRequests(nil, kyvernoNamespace, requests); err != nil {
+		if report, aggregatedRequests, err = g.mergeRequests(nil, kyvernoNamespace, policyName, requests); err != nil {
 			return nil, nil, fmt.Errorf("unable to merge ClusterReportChangeRequests results: %v", err)
 		}
 	} else {
@@ -561,13 +613,17 @@ func (g *ReportGenerator) aggregateReports(namespace string) (
 			ns.SetDeletionTimestamp(&now)
 		}
 
-		selector := labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, ResourceLabelNamespace: namespace}))
+		if g.splitPolicyReport {
+			selector = labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, ResourceLabelNamespace: namespace, policyLabel: TrimmedName(policyName)}))
+		} else {
+			selector = labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, ResourceLabelNamespace: namespace}))
+		}
 		requests, err := g.reportChangeRequestLister.ReportChangeRequests(config.KyvernoNamespace()).List(selector)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to list reportChangeRequests within namespace %s: %v", ns, err)
 		}
 
-		if report, aggregatedRequests, err = mergeRequests(ns, kyvernoNamespace, requests); err != nil {
+		if report, aggregatedRequests, err = g.mergeRequests(ns, kyvernoNamespace, policyName, requests); err != nil {
 			return nil, nil, fmt.Errorf("unable to merge results: %v", err)
 		}
 	}
@@ -575,9 +631,8 @@ func (g *ReportGenerator) aggregateReports(namespace string) (
 	return report, aggregatedRequests, nil
 }
 
-func mergeRequests(ns, kyvernoNs *corev1.Namespace, requestsGeneral interface{}) (*unstructured.Unstructured, interface{}, error) {
+func (g *ReportGenerator) mergeRequests(ns, kyvernoNs *corev1.Namespace, policyName string, requestsGeneral interface{}) (*unstructured.Unstructured, interface{}, error) {
 	results := []policyreportv1alpha2.PolicyReportResult{}
-
 	if requests, ok := requestsGeneral.([]*kyvernov1alpha2.ClusterReportChangeRequest); ok {
 		aggregatedRequests := []*kyvernov1alpha2.ClusterReportChangeRequest{}
 		for _, request := range requests {
@@ -601,7 +656,9 @@ func mergeRequests(ns, kyvernoNs *corev1.Namespace, requestsGeneral interface{})
 		}
 
 		req := &unstructured.Unstructured{Object: obj}
-		setReport(req, nil, kyvernoNs)
+
+		g.setReport(req, ns, kyvernoNs, policyName)
+
 		return req, aggregatedRequests, nil
 	}
 
@@ -628,7 +685,8 @@ func mergeRequests(ns, kyvernoNs *corev1.Namespace, requestsGeneral interface{})
 		}
 
 		req := &unstructured.Unstructured{Object: obj}
-		setReport(req, ns, kyvernoNs)
+
+		g.setReport(req, ns, kyvernoNs, policyName)
 
 		return req, aggregatedRequests, nil
 	}
@@ -636,7 +694,7 @@ func mergeRequests(ns, kyvernoNs *corev1.Namespace, requestsGeneral interface{})
 	return nil, nil, nil
 }
 
-func setReport(reportUnstructured *unstructured.Unstructured, ns, kyvernoNs *corev1.Namespace) {
+func (g *ReportGenerator) setReport(reportUnstructured *unstructured.Unstructured, ns, kyvernoNs *corev1.Namespace, policyname string) {
 	reportUnstructured.SetAPIVersion(policyreportv1alpha2.SchemeGroupVersion.String())
 	reportUnstructured.SetLabels(LabelSelector.MatchLabels)
 
@@ -655,12 +713,20 @@ func setReport(reportUnstructured *unstructured.Unstructured, ns, kyvernoNs *cor
 	}
 
 	if ns == nil {
-		reportUnstructured.SetName(GeneratePolicyReportName(""))
+		if g.splitPolicyReport {
+			reportUnstructured.SetName(TrimmedName(GeneratePolicyReportName("") + "-" + policyname))
+		} else {
+			reportUnstructured.SetName(GeneratePolicyReportName(""))
+		}
 		reportUnstructured.SetKind("ClusterPolicyReport")
 		return
 	}
 
-	reportUnstructured.SetName(GeneratePolicyReportName(ns.GetName()))
+	if g.splitPolicyReport {
+		reportUnstructured.SetName(TrimmedName(GeneratePolicyReportName(ns.GetName()) + "-" + policyname))
+	} else {
+		reportUnstructured.SetName(GeneratePolicyReportName(ns.GetName()))
+	}
 	reportUnstructured.SetNamespace(ns.GetName())
 	reportUnstructured.SetKind("PolicyReport")
 }
@@ -776,6 +842,62 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 	}
 
 	g.log.V(3).Info("successfully updated policy report", "kind", new.GetKind(), "namespace", new.GetNamespace(), "name", new.GetName())
+	return
+}
+
+func (g *ReportGenerator) updateReportsForDeletedResource(resName string, new *unstructured.Unstructured, aggregatedRequests interface{}) (err error) {
+	if _, ok := aggregatedRequests.([]*kyvernov1alpha2.ClusterReportChangeRequest); ok {
+		cpolrs, err := g.clusterReportLister.List(labels.Everything())
+		if err != nil {
+			return fmt.Errorf("failed to list clusterPolicyReport %v", err)
+		}
+		for _, cpolr := range cpolrs {
+			newRes := []policyreportv1alpha2.PolicyReportResult{}
+			for _, result := range cpolr.Results {
+				if len(result.Resources) != 0 {
+					for _, res := range result.Resources {
+						if res.Name != resName {
+							newRes = append(newRes, result)
+						}
+					}
+				}
+			}
+			cpolr.Results = newRes
+			cpolr.Summary = calculateSummary(newRes)
+			gv := policyreportv1alpha2.SchemeGroupVersion
+			cpolr.SetGroupVersionKind(schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: "ClusterPolicyReport"})
+			if _, err := g.pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("failed to update clusterPolicyReport %s %v", cpolr.Name, err)
+			}
+		}
+	} else {
+		polrs, err := g.reportLister.List(labels.Everything())
+		if err != nil {
+			return fmt.Errorf("failed to list clusterPolicyReport %v", err)
+		}
+		for _, polr := range polrs {
+			newRes1 := []policyreportv1alpha2.PolicyReportResult{}
+			for _, result := range polr.Results {
+				if len(result.Resources) != 0 {
+					for _, res := range result.Resources {
+						if res.Name != resName {
+							newRes1 = append(newRes1, result)
+						}
+					}
+				}
+			}
+			polr.Results = newRes1
+			polr.Summary = calculateSummary(newRes1)
+			gv := policyreportv1alpha2.SchemeGroupVersion
+
+			polr.SetGroupVersionKind(schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: "PolicyReport"})
+
+			if _, err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(new.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("failed to update clusterPolicyReport %s %v", polr.Name, err)
+			}
+		}
+	}
+
 	return
 }
 

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -40,6 +40,10 @@ const (
 
 	LabelSelectorKey   = "managed-by"
 	LabelSelectorValue = "kyverno"
+
+	deletedPolicyKey = "deletedpolicy"
+
+	resourceExhaustedErr = "ResourceExhausted"
 )
 
 var LabelSelector = &metav1.LabelSelector{
@@ -72,6 +76,8 @@ type ReportGenerator struct {
 	// if send true, the reports' results will be erased, this is used to recover from the invalid records
 	ReconcileCh chan bool
 
+	cleanupChangeRequest chan<- ReconcileInfo
+
 	log logr.Logger
 }
 
@@ -84,6 +90,7 @@ func NewReportGenerator(
 	reportReqInformer kyvernov1alpha2informers.ReportChangeRequestInformer,
 	clusterReportReqInformer kyvernov1alpha2informers.ClusterReportChangeRequestInformer,
 	namespace corev1informers.NamespaceInformer,
+	cleanupChangeRequest chan<- ReconcileInfo,
 	log logr.Logger,
 ) (*ReportGenerator, error) {
 	gen := &ReportGenerator{
@@ -95,6 +102,7 @@ func NewReportGenerator(
 		clusterReportReqInformer: clusterReportReqInformer,
 		queue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), prWorkQueueName),
 		ReconcileCh:              make(chan bool, 10),
+		cleanupChangeRequest:     cleanupChangeRequest,
 		log:                      log,
 	}
 
@@ -107,8 +115,6 @@ func NewReportGenerator(
 	gen.informersSynced = []cache.InformerSynced{clusterReportInformer.Informer().HasSynced, reportInformer.Informer().HasSynced, reportReqInformer.Informer().HasSynced, clusterReportInformer.Informer().HasSynced, namespace.Informer().HasSynced}
 	return gen, nil
 }
-
-const deletedPolicyKey string = "deletedpolicy"
 
 // the key of queue can be
 // - <namespace name> for the resource
@@ -123,7 +129,7 @@ func generateCacheKey(changeRequest interface{}) string {
 			return strings.Join([]string{deletedPolicyKey, policy, rule}, "/")
 		}
 
-		ns := label[resourceLabelNamespace]
+		ns := label[ResourceLabelNamespace]
 		if ns == "" {
 			ns = "default"
 		}
@@ -318,16 +324,24 @@ func (g *ReportGenerator) handleErr(err error, key interface{}, aggregatedReques
 // otherwise it updates policyReport
 func (g *ReportGenerator) syncHandler(key string) (aggregatedRequests interface{}, err error) {
 	g.log.V(4).Info("syncing policy report", "key", key)
+	namespace := key
 
 	if policy, rule, ok := isDeletedPolicyKey(key); ok {
 		g.log.V(4).Info("sync policy report on policy deletion")
 		return g.removePolicyEntryFromReport(policy, rule)
 	}
 
-	namespace := key
 	new, aggregatedRequests, err := g.aggregateReports(namespace)
 	if err != nil {
 		return aggregatedRequests, fmt.Errorf("failed to aggregate reportChangeRequest results %v", err)
+	}
+
+	report, err := g.reportLister.PolicyReports(namespace).Get(GeneratePolicyReportName(namespace))
+	if err == nil {
+		if val, ok := report.GetLabels()[inactiveLabelKey]; ok && val == inactiveLabelVal {
+			g.log.Info("got resourceExhausted error, please opt-in via \"splitPolicyReport\" to generate report per policy")
+			return aggregatedRequests, nil
+		}
 	}
 
 	var old interface{}
@@ -547,7 +561,7 @@ func (g *ReportGenerator) aggregateReports(namespace string) (
 			ns.SetDeletionTimestamp(&now)
 		}
 
-		selector := labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, resourceLabelNamespace: namespace}))
+		selector := labels.SelectorFromSet(labels.Set(map[string]string{appVersion: version.BuildVersion, ResourceLabelNamespace: namespace}))
 		requests, err := g.reportChangeRequestLister.ReportChangeRequests(config.KyvernoNamespace()).List(selector)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to list reportChangeRequests within namespace %s: %v", ns, err)
@@ -701,6 +715,29 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 			return fmt.Errorf("error converting to PolicyReport: %v", err)
 		}
 		if _, err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(new.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+			if strings.Contains(err.Error(), resourceExhaustedErr) {
+				g.log.V(4).Info("got ResourceExhausted error, cleanning up change requests and erasing report results")
+
+				annotations := polr.GetAnnotations()
+				if annotations == nil {
+					annotations = make(map[string]string)
+				}
+				annotations[inactiveLabelKey] = "Unable to update policy report due to resourceExhausted error, please enable the flag \"splitPolicyReport\" to generate a report per policy"
+				polr.SetAnnotations(annotations)
+
+				labels := polr.GetLabels()
+				labels[inactiveLabelKey] = inactiveLabelVal
+				polr.SetLabels(labels)
+
+				polr.Results = []policyreportv1alpha2.PolicyReportResult{}
+				polr.Summary = policyreportv1alpha2.PolicyReportSummary{}
+				if _, err := g.pclient.Wgpolicyk8sV1alpha2().PolicyReports(new.GetNamespace()).Update(context.TODO(), polr, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("failed to erase policy report results: %v", err)
+				}
+				ns := new.GetNamespace()
+				g.cleanupChangeRequest <- ReconcileInfo{Namespace: &ns, MapperInactive: true}
+				return nil
+			}
 			return fmt.Errorf("failed to update PolicyReport: %v", err)
 		}
 	}
@@ -711,6 +748,29 @@ func (g *ReportGenerator) updateReport(old interface{}, new *unstructured.Unstru
 			return fmt.Errorf("error converting to ClusterPolicyReport: %v", err)
 		}
 		if _, err := g.pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+			if strings.Contains(err.Error(), resourceExhaustedErr) {
+				g.log.V(4).Info("got ResourceExhausted error, cleanning up change requests and erasing report results")
+
+				annotations := cpolr.GetAnnotations()
+				if annotations == nil {
+					annotations = make(map[string]string)
+				}
+				annotations[inactiveLabelKey] = "Unable to update cluster policy report due to resourceExhausted error, please enable the flag \"splitPolicyReport\" to generate report per policy"
+				cpolr.SetAnnotations(annotations)
+
+				labels := cpolr.GetLabels()
+				labels[inactiveLabelKey] = inactiveLabelVal
+				cpolr.SetLabels(labels)
+
+				cpolr.Results = []policyreportv1alpha2.PolicyReportResult{}
+				cpolr.Summary = policyreportv1alpha2.PolicyReportSummary{}
+				if _, err := g.pclient.Wgpolicyk8sV1alpha2().ClusterPolicyReports().Update(context.TODO(), cpolr, metav1.UpdateOptions{}); err != nil {
+					return fmt.Errorf("failed to erase cluster policy report results: %v", err)
+				}
+				ns := ""
+				g.cleanupChangeRequest <- ReconcileInfo{Namespace: &ns, MapperInactive: true}
+				return nil
+			}
 			return fmt.Errorf("failed to update ClusterPolicyReport: %v", err)
 		}
 	}

--- a/pkg/policyreport/reportcontroller.go
+++ b/pkg/policyreport/reportcontroller.go
@@ -64,6 +64,8 @@ type ReportGenerator struct {
 	clusterReportChangeRequestLister kyvernov1alpha2listers.ClusterReportChangeRequestLister
 	nsLister                         corev1listers.NamespaceLister
 
+	informersSynced []cache.InformerSynced
+
 	queue workqueue.RateLimitingInterface
 
 	// ReconcileCh sends a signal to policy controller to force the reconciliation of policy report
@@ -102,6 +104,7 @@ func NewReportGenerator(
 	gen.reportChangeRequestLister = reportReqInformer.Lister()
 	gen.nsLister = namespace.Lister()
 
+	gen.informersSynced = []cache.InformerSynced{clusterReportInformer.Informer().HasSynced, reportInformer.Informer().HasSynced, reportReqInformer.Informer().HasSynced, clusterReportInformer.Informer().HasSynced, namespace.Informer().HasSynced}
 	return gen, nil
 }
 
@@ -230,6 +233,10 @@ func (g *ReportGenerator) Run(workers int, stopCh <-chan struct{}) {
 
 	logger.Info("start")
 	defer logger.Info("shutting down")
+
+	if !cache.WaitForNamedCacheSync("PolicyReportGenerator", stopCh, g.informersSynced...) {
+		return
+	}
 
 	g.reportReqInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -17,6 +17,7 @@ import (
 	kyvernov1alpha2listers "github.com/kyverno/kyverno/pkg/client/listers/kyverno/v1alpha2"
 	"github.com/kyverno/kyverno/pkg/dclient"
 	"github.com/kyverno/kyverno/pkg/engine/response"
+	cmap "github.com/orcaman/concurrent-map"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -36,6 +37,9 @@ type Generator struct {
 
 	clusterReportChangeRequestLister kyvernov1alpha2listers.ClusterReportChangeRequestLister
 
+	// changeRequestMapper stores the change requests' count per namespace
+	changeRequestMapper concurrentMap
+
 	// cpolLister can list/get policy from the shared informer's store
 	cpolLister kyvernov1listers.ClusterPolicyLister
 
@@ -49,6 +53,12 @@ type Generator struct {
 
 	requestCreator creator
 
+	// changeRequestLimit defines the max count for change requests (per namespace for RCR / cluster-wide for CRCR)
+	changeRequestLimit int
+
+	// CleanupChangeRequest signals the policy report controller to cleanup change requests
+	CleanupChangeRequest chan ReconcileInfo
+
 	log logr.Logger
 }
 
@@ -59,22 +69,31 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 	clusterReportReqInformer kyvernov1alpha2informers.ClusterReportChangeRequestInformer,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	polInformer kyvernov1informers.PolicyInformer,
+	changeRequestLimit int,
 	log logr.Logger,
 ) *Generator {
 	gen := Generator{
 		dclient:                          dclient,
 		clusterReportChangeRequestLister: clusterReportReqInformer.Lister(),
 		reportChangeRequestLister:        reportReqInformer.Lister(),
+		changeRequestMapper:              newChangeRequestMapper(),
 		cpolLister:                       cpolInformer.Lister(),
 		polLister:                        polInformer.Lister(),
 		queue:                            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
 		dataStore:                        newDataStore(),
 		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, log.WithName("requestCreator")),
+		changeRequestLimit:               changeRequestLimit,
+		CleanupChangeRequest:             make(chan ReconcileInfo, 10),
 		log:                              log,
 	}
 
 	gen.informersSynced = []cache.InformerSynced{clusterReportReqInformer.Informer().HasSynced, reportReqInformer.Informer().HasSynced, cpolInformer.Informer().HasSynced, polInformer.Informer().HasSynced}
 	return &gen
+}
+
+type ReconcileInfo struct {
+	Namespace      *string
+	MapperInactive bool
 }
 
 // NewDataStore returns an instance of data store
@@ -143,9 +162,17 @@ func (i Info) GetRuleLength() int {
 	return l
 }
 
+func parseKeyHash(keyHash string) (policyName, ns string) {
+	keys := strings.Split(keyHash, "/")
+	return keys[0], keys[1]
+}
+
 // GeneratorInterface provides API to create PVs
 type GeneratorInterface interface {
 	Add(infos ...Info)
+	MapperReset(string)
+	MapperInactive(string)
+	MapperInvalidate()
 }
 
 func (gen *Generator) enqueue(info Info) {
@@ -157,7 +184,32 @@ func (gen *Generator) enqueue(info Info) {
 // Add queues a policy violation create request
 func (gen *Generator) Add(infos ...Info) {
 	for _, info := range infos {
+		count, ok := gen.changeRequestMapper.ConcurrentMap.Get(info.Namespace)
+		if ok && count == -1 {
+			gen.log.V(6).Info("inactive policy report, skip creating report change request", "namespace", info.Namespace)
+			continue
+		}
+
+		gen.changeRequestMapper.increase(info.Namespace)
 		gen.enqueue(info)
+	}
+}
+
+// MapperReset resets the change request mapper for the given namespace
+func (gen Generator) MapperReset(ns string) {
+	gen.changeRequestMapper.ConcurrentMap.Set(ns, 0)
+}
+
+// MapperInactive sets the change request mapper for the given namespace to -1
+// which indicates the report is inactive
+func (gen Generator) MapperInactive(ns string) {
+	gen.changeRequestMapper.ConcurrentMap.Set(ns, -1)
+}
+
+// MapperInvalidate reset map entries
+func (gen Generator) MapperInvalidate() {
+	for ns := range gen.changeRequestMapper.ConcurrentMap.Items() {
+		gen.changeRequestMapper.ConcurrentMap.Remove(ns)
 	}
 }
 
@@ -196,6 +248,7 @@ func (gen *Generator) handleErr(err error, key interface{}) {
 	if err == nil {
 		gen.queue.Forget(key)
 		gen.dataStore.delete(keyHash)
+		gen.changeRequestMapper.decrease(keyHash)
 		return
 	}
 
@@ -209,6 +262,7 @@ func (gen *Generator) handleErr(err error, key interface{}) {
 	logger.Error(err, "failed to process report request", "key", key)
 	gen.queue.Forget(key)
 	gen.dataStore.delete(keyHash)
+	gen.changeRequestMapper.decrease(keyHash)
 }
 
 func (gen *Generator) processNextWorkItem() bool {
@@ -218,32 +272,37 @@ func (gen *Generator) processNextWorkItem() bool {
 		return false
 	}
 
-	err := func(obj interface{}) error {
-		defer gen.queue.Done(obj)
-		var keyHash string
-		var ok bool
+	defer gen.queue.Done(obj)
+	var keyHash string
+	var ok bool
 
-		if keyHash, ok = obj.(string); !ok {
-			gen.queue.Forget(obj)
-			logger.Info("incorrect type; expecting type 'string'", "obj", obj)
-			return nil
-		}
-
-		// lookup data store
-		info := gen.dataStore.lookup(keyHash)
-		if reflect.DeepEqual(info, Info{}) {
-			gen.queue.Forget(obj)
-			logger.V(4).Info("empty key")
-			return nil
-		}
-
-		err := gen.syncHandler(info)
-		gen.handleErr(err, obj)
-		return nil
-	}(obj)
-	if err != nil {
-		logger.Error(err, "failed to process item")
+	if keyHash, ok = obj.(string); !ok {
+		logger.Info("incorrect type; expecting type 'string'", "obj", obj)
+		gen.handleErr(nil, obj)
+		return true
 	}
+
+	// lookup data store
+	info := gen.dataStore.lookup(keyHash)
+	if reflect.DeepEqual(info, Info{}) {
+		logger.V(4).Info("empty key")
+		gen.handleErr(nil, obj)
+		return true
+	}
+
+	count, ok := gen.changeRequestMapper.Get(info.Namespace)
+	if ok {
+		if count.(int) > gen.changeRequestLimit {
+			logger.Info("throttling report change requests", "namespace", info.Namespace, "threshold", gen.changeRequestLimit, "count", count.(int))
+			gen.CleanupChangeRequest <- ReconcileInfo{Namespace: &(info.Namespace), MapperInactive: false}
+			gen.queue.Forget(obj)
+			gen.dataStore.delete(keyHash)
+			return true
+		}
+	}
+
+	err := gen.syncHandler(info)
+	gen.handleErr(err, obj)
 
 	return true
 }
@@ -278,4 +337,8 @@ func hasResultsChanged(old, new map[string]interface{}) bool {
 	}
 
 	return !reflect.DeepEqual(oldRes, newRes)
+}
+
+func newChangeRequestMapper() concurrentMap {
+	return concurrentMap{cmap.New()}
 }

--- a/pkg/policyreport/reportrequest.go
+++ b/pkg/policyreport/reportrequest.go
@@ -70,6 +70,7 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 	cpolInformer kyvernov1informers.ClusterPolicyInformer,
 	polInformer kyvernov1informers.PolicyInformer,
 	changeRequestLimit int,
+	splitPolicyReport bool,
 	log logr.Logger,
 ) *Generator {
 	gen := Generator{
@@ -81,9 +82,9 @@ func NewReportChangeRequestGenerator(client kyvernoclient.Interface,
 		polLister:                        polInformer.Lister(),
 		queue:                            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
 		dataStore:                        newDataStore(),
-		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, log.WithName("requestCreator")),
 		changeRequestLimit:               changeRequestLimit,
 		CleanupChangeRequest:             make(chan ReconcileInfo, 10),
+		requestCreator:                   newChangeRequestCreator(client, 3*time.Second, splitPolicyReport, log.WithName("requestCreator")),
 		log:                              log,
 	}
 

--- a/pkg/webhooks/resource/report.go
+++ b/pkg/webhooks/resource/report.go
@@ -21,17 +21,17 @@ func generateEvents(engineResponses []*response.EngineResponse, blocked bool, lo
 			for i, ruleResp := range er.PolicyResponse.Rules {
 				if ruleResp.Status == response.RuleStatusFail || ruleResp.Status == response.RuleStatusError {
 					e := event.NewPolicyFailEvent(event.AdmissionController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i], blocked)
-					events = append(events, *e)
+					events = append(events, e)
 				}
 
 				if !blocked {
 					e := event.NewResourceViolationEvent(event.AdmissionController, event.PolicyViolation, er, &er.PolicyResponse.Rules[i])
-					events = append(events, *e)
+					events = append(events, e)
 				}
 			}
 		} else {
 			e := event.NewPolicyAppliedEvent(event.AdmissionController, er)
-			events = append(events, *e)
+			events = append(events, e)
 		}
 	}
 

--- a/pkg/webhooks/resource/validate_audit.go
+++ b/pkg/webhooks/resource/validate_audit.go
@@ -24,6 +24,7 @@ import (
 	rbacv1informers "k8s.io/client-go/informers/rbac/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -52,6 +53,8 @@ type auditHandler struct {
 	crbLister rbacv1listers.ClusterRoleBindingLister
 	nsLister  corev1listers.NamespaceLister
 
+	informersSynced []cache.InformerSynced
+
 	log           logr.Logger
 	configHandler config.Configuration
 	promConfig    *metrics.PromConfig
@@ -69,7 +72,7 @@ func NewValidateAuditHandler(pCache policycache.Cache,
 	client dclient.Interface,
 	promConfig *metrics.PromConfig,
 ) AuditHandler {
-	return &auditHandler{
+	c := &auditHandler{
 		pCache:        pCache,
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), workQueueName),
 		eventGen:      eventGen,
@@ -82,6 +85,8 @@ func NewValidateAuditHandler(pCache policycache.Cache,
 		client:        client,
 		promConfig:    promConfig,
 	}
+	c.informersSynced = []cache.InformerSynced{rbInformer.Informer().HasSynced, crbInformer.Informer().HasSynced, namespaces.Informer().HasSynced}
+	return c
 }
 
 func (h *auditHandler) Add(request *admissionv1.AdmissionRequest) {
@@ -96,6 +101,10 @@ func (h *auditHandler) Run(workers int, stopCh <-chan struct{}) {
 		utilruntime.HandleCrash()
 		h.log.V(4).Info("shutting down")
 	}()
+
+	if !cache.WaitForNamedCacheSync("ValidateAuditHandler", stopCh, h.informersSynced...) {
+		return
+	}
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(h.runWorker, time.Second, stopCh)

--- a/pkg/webhooks/resource/validation.go
+++ b/pkg/webhooks/resource/validation.go
@@ -94,8 +94,10 @@ func (v *validationHandler) handleValidation(
 	// Scenario 3:
 	//   all policies were applied successfully.
 	//   create an event on the resource
-	events := generateEvents(engineResponses, blocked, logger)
-	v.eventGen.Add(events...)
+	if deletionTimeStamp == nil {
+		events := generateEvents(engineResponses, blocked, logger)
+		v.eventGen.Add(events...)
+	}
 
 	if blocked {
 		logger.V(4).Info("resource blocked")


### PR DESCRIPTION
Signed-off-by: samidbb <samdi@dfds.com>

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->
/kind cleanup

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

***NOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.
-->
Increase the default memory limit in the Helm chart. The memory limit is too low. We have a minimal setup of kyverno in our current production setup: only 2 policies and yet it used all the memory that was assigned - see comments.

### Proof Manifests

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) and Kyverno CLI test manifests which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```

# Kyverno CLI test manifest (please see docs for latest manifest format at https://kyverno.io/docs/kyverno-cli/). See kyverno/policies for complete examples of all related test files.

```yaml
name: prepend-image-registry
policies:
  - prepend_image_registry.yaml
resources:
  - resource.yaml
variables: values.yaml
results:
  - policy: prepend-registry
    rule: prepend-registry-containers
    resource: mypod
    # if mutate rule
    patchedResource: patchedResource01.yaml
    kind: Pod
    result: pass
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.
- [ ] My PR contains new or altered behavior to Kyverno and
  - [ ] CLI support should be added and my PR doesn't contain that functionality.
  - [ ] I have added or changed [the documentation](https://github.com/kyverno/website) myself in an existing PR and the link is:
  <!-- Uncomment to link to the PR -->
  <!-- https://github.com/kyverno/website/pull/123 -->
  - [ ] I have raised an issue in [kyverno/website](https://github.com/kyverno/website) to track the documentation update and the link is:
  <!-- Uncomment to link to the issue -->
  <!-- https://github.com/kyverno/website/issues/1 -->

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
